### PR TITLE
Bugfixing and Refactoring parse.py

### DIFF
--- a/rnlp/__init__.py
+++ b/rnlp/__init__.py
@@ -74,10 +74,9 @@ __credits__ = [
     'Rahul Pasunuri'
 ]
 
-from . import parse
-
 from .textprocessing import getBlocks
 from .textprocessing import getSentences
+from .parse import makeIdentifiers
 
 def converter(input_string, block_size=2):
     """

--- a/rnlp/__init__.py
+++ b/rnlp/__init__.py
@@ -56,6 +56,10 @@ Examples
                 predicates = rnlp.parse(declaration)
 """
 
+from .textprocessing import getBlocks
+from .textprocessing import getSentences
+from .parse import makeIdentifiers
+
 __author__ = 'Kaushik Roy (@kkroy36)'
 __copyright__ = 'Copyright (c) 2017-2018 StARLinG Lab'
 __license__ = 'GPL-v3'
@@ -74,9 +78,6 @@ __credits__ = [
     'Rahul Pasunuri'
 ]
 
-from .textprocessing import getBlocks
-from .textprocessing import getSentences
-from .parse import makeIdentifiers
 
 def converter(input_string, block_size=2):
     """

--- a/rnlp/__main__.py
+++ b/rnlp/__main__.py
@@ -65,11 +65,11 @@ parser = argparse.ArgumentParser(
 file_or_dir = parser.add_mutually_exclusive_group()
 
 parser.add_argument('-b', '--blockSize', type=int, default=2,
-    help='Set the block size')
+                    help='Set the block size')
 file_or_dir.add_argument('-d', '--directory', type=str,
-    help='Read text from all files in a directory.')
+                         help='Read text from all files in a directory.')
 file_or_dir.add_argument('-f', '--file', type=str,
-    help='Read from text from a file.')
+                         help='Read from text from a file.')
 
 args = parser.parse_args()
 logger.info('Argument Parsing Successful.')

--- a/rnlp/corpus.py
+++ b/rnlp/corpus.py
@@ -27,7 +27,8 @@ Built-in corpus and utilities for reading corpora from files.
 """
 
 from os import listdir
-from tqdm  import tqdm
+from tqdm import tqdm
+
 
 def readCorpus(location):
     """
@@ -75,6 +76,7 @@ def readCorpus(location):
                 corpus += fp.read()
 
     return corpus
+
 
 def declaration():
     """
@@ -134,8 +136,9 @@ def declaration():
     public good.
 
     He has forbidden his Governors to pass Laws of immediate and pressing
-    importance, unless suspended in their operation till his Assent should be
-    obtained; and when so suspended, he has utterly neglected to attend to them.
+    importance, unless suspended in their operation till his Assent should
+    be obtained; and when so suspended, he has utterly neglected to attend
+    to them.
 
     He has refused to pass other Laws for the accommodation of large districts
     of people, unless those people would relinquish the right of Representation

--- a/rnlp/parse.py
+++ b/rnlp/parse.py
@@ -34,37 +34,43 @@ from tqdm import tqdm
 from .textprocessing import getSentences
 from .textprocessing import getBlocks
 
-def _writeBlock(block,blockID):
+
+def _writeBlock(block, blockID):
     '''writes the block to a file with the id'''
-    with open("blockIDs.txt","a") as fp:
-        fp.write("blockID: "+str(blockID)+"\n")
+    with open("blockIDs.txt", "a") as fp:
+        fp.write("blockID: " + str(blockID) + "\n")
         sentences = ""
         for sentence in block:
             sentences += sentence+","
         fp.write("block sentences: "+sentences[:-1]+"\n")
         fp.write("\n")
 
-def _writeSentenceInBlock(sentence,blockID,sentenceID):
+
+def _writeSentenceInBlock(sentence, blockID, sentenceID):
     '''writes the sentence in a block to a file with the id'''
-    with open("sentenceIDs.txt","a") as fp:
+    with open("sentenceIDs.txt", "a") as fp:
         fp.write("sentenceID: "+str(blockID)+"_"+str(sentenceID)+"\n")
         fp.write("sentence string: "+sentence+"\n")
         fp.write("\n")
 
-def _writeWordFromSentenceInBlock(word,blockID,sentenceID,wordID):
+
+def _writeWordFromSentenceInBlock(word, blockID, sentenceID, wordID):
     '''writes the word from a sentence in a block to a file with the id'''
-    with open("wordIDs.txt","a") as fp:
-        fp.write("wordID: "+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+"\n")
-        fp.write("wordString: "+word+"\n")
+    with open("wordIDs.txt", "a") as fp:
+        fp.write("wordID: " + str(blockID) + "_" +
+                 str(sentenceID) + "_" + str(wordID) + "\n")
+        fp.write("wordString: " + word + "\n")
         fp.write("\n")
+
 
 def _writeFact(predicateString):
     '''writes the fact to facts file'''
-    with open("facts.txt","a") as f:
+    with open("facts.txt", "a") as f:
         f.write(predicateString+"\n")
 
+
 def _writeBk(target="sentenceContainsTarget(+SID,+WID).", treeDepth="3",
-            nodeSize="3", numOfClauses="8"):
+             nodeSize="3", numOfClauses="8"):
     """
     Writes a background file to disk.
 
@@ -103,6 +109,7 @@ def _writeBk(target="sentenceContainsTarget(+SID,+WID).", treeDepth="3",
         bk.write("mode: " + target + "\n")
 
     return
+
 
 def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
                     treeDepth="3", nodeSize="3", numOfClauses="8"):
@@ -148,8 +155,6 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
     """
 
     blockID, sentenceID, wordID = 1, 0, 0
-
-    #checkConsistency()
 
     print("Creating background file...")
 
@@ -204,10 +209,6 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
             wordID = 1
             tokens = nltk.word_tokenize(sentence)
             nWords = len(tokens)
-
-
-            # Adding these two in, the other two will overwrite
-            # the variables defined above.
             wBeginning = nWords/float(3)
             wEnding = (2*nWords)/float(3)
 
@@ -257,14 +258,14 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
                 elif wordID > wEnding:
                     # mode: lateWordInSentence(sentenceID< wordID).
                     ps = "lateWordInSentence(" + str(blockID) + "_" + \
-                    str(sentenceID) + "," + str(blockID) + "_" + \
-                    str(sentenceID) + "_" + str(wordID) + ")."
+                         str(sentenceID) + "," + str(blockID) + "_" + \
+                         str(sentenceID) + "_" + str(wordID) + ")."
                     _writeFact(ps)
                 else:
                     # mode: midWayWordInSentence(sentenceID, wordID).
                     ps = "midWayWordInSentence(" + str(blockID) + "_" + \
-                    str(sentenceID) + "," + str(blockID) + "_" + \
-                    str(sentenceID) + "_" + str(wordID) + ")."
+                         str(sentenceID) + "," + str(blockID) + "_" + \
+                         str(sentenceID) + "_" + str(wordID) + ")."
                     _writeFact(ps)
 
                 # mode: wordInSentence(wordID, sentenceID).
@@ -272,7 +273,7 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
                      str(sentenceID) + "_" + str(wordID) + "," + \
                      str(blockID) + "_" + str(sentenceID) + ")."
                 _writeFact(ps)
-                _writeWordFromSentenceInBlock(word, blockID, sentenceID, wordID)
-
+                _writeWordFromSentenceInBlock(word, blockID,
+                                              sentenceID, wordID)
                 wordID += 1
         blockID += 1

--- a/rnlp/parse.py
+++ b/rnlp/parse.py
@@ -25,11 +25,6 @@ rnlp.parse
 from __future__ import print_function
 from __future__ import division
 
-try:
-   input = raw_input
-except NameError:
-   pass
-
 # Standard Python Library
 import string
 
@@ -162,6 +157,7 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
              nodeSize=nodeSize, numOfClauses=numOfClauses)
 
     print("Creating identifiers from the blocks...")
+
     nBlocks = len(blocks)
     for block in tqdm(blocks):
 
@@ -208,13 +204,17 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
             wordID = 1
             tokens = nltk.word_tokenize(sentence)
             nWords = len(tokens)
-            beginning = nWords/float(3)
-            ending = (2*nWords)/float(3)
+
+
+            # Adding these two in, the other two will overwrite
+            # the variables defined above.
+            wBeginning = nWords/float(3)
+            wEnding = (2*nWords)/float(3)
 
             for word in tokens:
-                #============predicate: wordString(wordID,#str)==================
-                '''
-                if word == "you":
+
+                """
+                if word == "He":
                     pos = open("pos.txt","a")
                     word = str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)
                     sentence = str(blockID)+"_"+str(sentenceID)
@@ -226,33 +226,53 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
                     sentence = str(blockID)+"_"+str(sentenceID)
                     neg.write("sentenceContainsTarget("+sentence+","+word+").\n")
                     neg.close()
-                '''
-                predicateString = "wordString("+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+","+"\'"+str(word)+"\')."
-                _writeFact(predicateString)
-                #============predicate: partOfSpeechTag(wordID,#POS)=============
+                """
+
+                # mode: wordString(wordID, #str).
+                ps = "wordString(" + str(blockID) + "_" + str(sentenceID) + \
+                     "_" + str(wordID) + "," + "'" + str(word) + "')."
+                _writeFact(ps)
+
+                # mode: partOfSpeechTag(wordID, #POS).
                 POS = nltk.pos_tag([word])[0][1]
-                predicateString = "partOfSpeech("+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+","+"\""+str(POS)+"\")."
-                _writeFact(predicateString)
+                ps = "partOfSpeech(" + str(blockID) + "_" + str(sentenceID) + \
+                     "_" + str(wordID) + "," + '"' + str(POS) + '").'
+                _writeFact(ps)
+
+                # mode: nextWordInSentence(sentenceID, wordID, wordID).
                 if wordID < nWords:
-                    #====================predicate: nextWordInSentence(sentenceID,wordID,wordID)==========================
-                    predicateString = "nextWordInSentence("+str(blockID)+"_"+str(sentenceID)+","+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+","+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID+1)+")."
-                    _writeFact(predicateString)
-                #=====================predicate: earlyWordInSentence(sentenceID,wordID)===========================
-                if wordID < beginning:
-                    predicateString = "earlyWordInSentence("+str(blockID)+"_"+str(sentenceID)+","+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+")."
-                    _writeFact(predicateString)
-                #=====================predicate: midWayWordInSentences(sentenceID,wordID)==========================
-                if wordID >= beginning and wordID < ending:
-                    predicateString = "midWayWordInSentence("+str(blockID)+"_"+str(sentenceID)+","+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+")."
-                    _writeFact(predicateString)
-                #=====================predicate: lateWordInSentence(sentenceID,wordID)============================
-                if sentenceID > ending:
-                    predicateString = "lateSentenceInBlock("+str(blockID)+","+str(blockID)+"_"+str(sentenceID)+")."
-                    _writeFact(predicateString)
-                #print("writing word "+str(wordID)+"/"+str(nWords)+" from sentence id "+str(sentenceID)+" in block id "+str(blockID)+" to wordIDs.txt..")
-                #====================predicate: wordInSentence(wordID,sentenceID)=====================================
-                predicateString = "wordInSentence("+str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)+","+str(blockID)+"_"+str(sentenceID)+")."
-                _writeFact(predicateString)
-                _writeWordFromSentenceInBlock(word,blockID,sentenceID,wordID)
+                    ps = "nextWordInSentence(" + str(blockID) + "_" + \
+                         str(sentenceID) + "," + str(blockID) + "_" + \
+                         str(sentenceID) + "_" + str(wordID) + "," + \
+                         str(blockID) + "_" + str(sentenceID) + "_" + \
+                         str(wordID+1) + ")."
+                    _writeFact(ps)
+
+                if wordID < wBeginning:
+                    # mode: earlyWordInSentence(sentenceID, wordID).
+                    ps = "earlyWordInSentence(" + str(blockID) + "_" + \
+                         str(sentenceID) + "," + str(blockID) + "_" + \
+                         str(sentenceID) + "_" + str(wordID) + ")."
+                    _writeFact(ps)
+                elif wordID > wEnding:
+                    # mode: lateWordInSentence(sentenceID< wordID).
+                    ps = "lateWordInSentence(" + str(blockID) + "_" + \
+                    str(sentenceID) + "," + str(blockID) + "_" + \
+                    str(sentenceID) + "_" + str(wordID) + ")."
+                    _writeFact(ps)
+                else:
+                    # mode: midWayWordInSentence(sentenceID, wordID).
+                    ps = "midWayWordInSentence(" + str(blockID) + "_" + \
+                    str(sentenceID) + "," + str(blockID) + "_" + \
+                    str(sentenceID) + "_" + str(wordID) + ")."
+                    _writeFact(ps)
+
+                # mode: wordInSentence(wordID, sentenceID).
+                ps = "wordInSentence(" + str(blockID) + "_" + \
+                     str(sentenceID) + "_" + str(wordID) + "," + \
+                     str(blockID) + "_" + str(sentenceID) + ")."
+                _writeFact(ps)
+                _writeWordFromSentenceInBlock(word, blockID, sentenceID, wordID)
+
                 wordID += 1
         blockID += 1

--- a/rnlp/parse.py
+++ b/rnlp/parse.py
@@ -151,8 +151,11 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
                     makeIdentifiers(blocks)
                     # 100%|██████████████████████| 2/2 [00:00<00:00, 18.49it/s]
     """
+
     blockID, sentenceID, wordID = 1, 0, 0
+
     #checkConsistency()
+
     print("Creating background file...")
 
     _writeBk(target=target, treeDepth=treeDepth,
@@ -172,32 +175,42 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
         for sentence in block:
 
             if sentenceID < nSentences:
-                #=====================predicate: nextSentenceInBlock(blockID,sentenceID,sentenceID)======================
-                predicateString = "nextSentenceInBlock("+str(blockID)+","+str(blockID)+"_"+str(sentenceID)+","+str(blockID)+"_"+str(sentenceID+1)+")."
-                _writeFact(predicateString)
-            #=====================predicate: earlySentenceInBlock(blockID,sentenceID)===========================
+                # mode: nextSentenceInBlock(blockID, sentenceID, sentenceID).
+                ps = "nextSentenceInBlock(" + str(blockID) + "," + \
+                     str(blockID) + "_" + str(sentenceID) + "," + \
+                     str(blockID) + "_" + str(sentenceID+1) + ")."
+                _writeFact(ps)
+
             if sentenceID < beginning:
-                predicateString = "earlySentenceInBlock("+str(blockID)+","+str(blockID)+"_"+str(sentenceID)+")."
-                _writeFact(predicateString)
-            #=====================predicate: midWaySentenceInBlock(blockID,sentenceID)==========================
-            if sentenceID >= beginning and sentenceID < ending:
-                predicateString = "earlySentenceInBlock("+str(blockID)+","+str(blockID)+"_"+str(sentenceID)+")."
-                _writeFact(predicateString)
-            #=====================predicate: lateSentenceInBlock(blockID,sentenceID)============================
-            if sentenceID > ending:
-                predicateString = "lateSentenceInBlock("+str(blockID)+","+str(blockID)+"_"+str(sentenceID)+")."
-                _writeFact(predicateString)
-            #print("writing sentence "+str(sentenceID)+"/"+str(nSentences)+" in block id "+str(blockID)+" to sentenceIDs.txt..")
-            #====================predicate: sentenceInBlock(sentenceID,blockID)=====================================
-            predicateString = "sentenceInBlock("+str(blockID)+"_"+str(sentenceID)+","+str(blockID)+")."
-            _writeFact(predicateString)
-            _writeSentenceInBlock(sentence,blockID,sentenceID)
+                # mode: earlySentenceInBlock(blockID, sentenceID).
+                ps = "earlySentenceInBlock(" + str(blockID) + "," + \
+                     str(blockID) + "_" + str(sentenceID) + ")."
+                _writeFact(ps)
+            elif sentenceID > ending:
+                # mode: lateSentenceInBlock(blockID, sentenceID).
+                ps = "lateSentenceInBlock(" + str(blockID) + "," + \
+                     str(blockID) + "_" + str(sentenceID) + ")."
+                _writeFact(ps)
+            else:
+                # mode: midWaySentenceInBlock(blockID, sentenceID).
+                ps = "earlySentenceInBlock(" + str(blockID) + "," + \
+                     str(blockID) + "_" + str(sentenceID) + ")."
+                _writeFact(ps)
+
+            # mode: sentenceInBlock(sentenceID, blockID).
+            ps = "sentenceInBlock(" + str(blockID) + "_" + str(sentenceID) + \
+                 "," + str(blockID) + ")."
+            _writeFact(ps)
+            _writeSentenceInBlock(sentence, blockID, sentenceID)
+
             sentenceID += 1
+
             wordID = 1
             tokens = nltk.word_tokenize(sentence)
             nWords = len(tokens)
             beginning = nWords/float(3)
             ending = (2*nWords)/float(3)
+
             for word in tokens:
                 #============predicate: wordString(wordID,#str)==================
                 '''

--- a/rnlp/tests/rnlptests/test_converter.py
+++ b/rnlp/tests/rnlptests/test_converter.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2017-2018 StARLinG Lab
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (at the base of this repository). If not,
+# see <http://www.gnu.org/licenses/>
+
+import sys
+import unittest
+
+sys.path.append('./')
+
+import rnlp
+
+class converterTest(unittest.TestCase):
+    """
+    This performs a similar test to test_parse.py, but uses rnlp.convert.
+    """
+
+    def test_converter_1(self):
+
+        example = "Hello there. How are you? I am fine."
+        rnlp.converter(example)

--- a/rnlp/tests/rnlptests/test_parse.py
+++ b/rnlp/tests/rnlptests/test_parse.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017-2018 StARLinG Lab
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (at the base of this repository). If not,
+# see <http://www.gnu.org/licenses/>
+
+import sys
+import unittest
+
+sys.path.append('./')
+
+from rnlp.textprocessing import getSentences
+from rnlp.textprocessing import getBlocks
+from rnlp import parse
+
+class makeIdentifiersTest(unittest.TestCase):
+    """
+    makeIdentifiers is not elegant to test in practice (since it does a
+    large amount of i/o).
+    """
+
+    def test_makeIdentifiers_1(self):
+
+        example = "Hello there. How are you? I am fine."
+        sentences = getSentences(example)
+        blocks = getBlocks(sentences, 2)
+
+        parse.makeIdentifiers(blocks)

--- a/rnlp/tests/rnlptests/test_textprocessing.py
+++ b/rnlp/tests/rnlptests/test_textprocessing.py
@@ -1,4 +1,18 @@
-# Copyright (c) 2017-2018 StARLinG Lab
+# Copyright (C) 2017-2018 StARLinG Lab
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (at the base of this repository). If not,
+# see <http://www.gnu.org/licenses/>
 
 import sys
 import unittest

--- a/rnlp/tests/rnlptests/test_textprocessing.py
+++ b/rnlp/tests/rnlptests/test_textprocessing.py
@@ -22,7 +22,7 @@ class removePunctuationTest(unittest.TestCase):
 
     def test_removePunctuation_3(self):
         sent = 'Hi.There'
-        self.assertEqual(textprocessing._removePunctuation(sent), 'Hi.There')
+        self.assertEqual(textprocessing._removePunctuation(sent), 'HiThere')
 
     def test_removePunctuation_4(self):
         import string
@@ -32,7 +32,7 @@ class removePunctuationTest(unittest.TestCase):
     def test_removePunctuation_5(self):
         sent = '(def add1 (lambda (n)) + n 1)'
         self.assertEqual(textprocessing._removePunctuation(sent),
-                         'def add1 (lambda (n)) + n 1')
+                         'def add1 lambda n  n 1')
 
 class removeStopwordsTest(unittest.TestCase):
 
@@ -89,8 +89,8 @@ class getBlocks(unittest.TestCase):
         breadlines blow my mind, and now this deadline.""")
         self.assertEqual(textprocessing.getBlocks(sents, 1),
         [['How do you document real life'],
-        ["When real life's getting more like fiction each day"],
-        ["Headlines,\n        breadlines blow my mind, and now this deadline"]])
+        ["When real lifes getting more like fiction each day"],
+        ["Headlines\n        breadlines blow my mind and now this deadline"]])
 
     def test_getBlocks_3(self):
         sents = textprocessing.getSentences(

--- a/rnlp/textprocessing.py
+++ b/rnlp/textprocessing.py
@@ -60,7 +60,10 @@ def _removePunctuation(text_string):
     >>> __removePunctuation(example)
     'Hello World'
     """
-    return text_string.strip(_punctuation)
+    try:
+        return text_string.translate(None, _punctuation)
+    except TypeError:
+        return text_string.translate(str.maketrans('', '', _punctuation))
 
 def _removeStopwords(text_list):
     """

--- a/rnlp/textprocessing.py
+++ b/rnlp/textprocessing.py
@@ -45,6 +45,7 @@ _punctuation = string.punctuation
 _stemmer = PorterStemmer()
 _stopwords = stopwords.words('english')
 
+
 def _removePunctuation(text_string):
     """
     Removes punctuation symbols from a string.
@@ -65,6 +66,7 @@ def _removePunctuation(text_string):
     except TypeError:
         return text_string.translate(str.maketrans('', '', _punctuation))
 
+
 def _removeStopwords(text_list):
     """
     Removes stopwords contained in a list of words.
@@ -83,6 +85,7 @@ def _removeStopwords(text_list):
             output_list.append(word)
 
     return output_list
+
 
 def getBlocks(sentences, n):
     """
@@ -115,6 +118,7 @@ def getBlocks(sentences, n):
     for i in range(0, len(sentences), n):
         blocks.append(sentences[i:(i+n)])
     return blocks
+
 
 def getSentences(text_string):
     """


### PR DESCRIPTION
This pull request re-factors the `makeIdentifiers()` function in parse.py and fixes a few fairly critical errors.

* `makeIdentifiers` is now imported by default when rnlp is imported.
*  Fixed a critical error in `parse.makeIdentifiers()` where the lateWordInSentence predicate was never created. In its place a second (and erroneous) lateSentenceInBlock predicate was created instead.
* The way punctuation was previously handled did not quite work correctly. `text_string.strip(_punctuation)` worked in most simple cases, but certain punctuation marks within sentences were problematic for BoostSRL's parser.