### PR TITLE
♻️ [MAINT] setup.py fixes, linter fixes, restructure common tags into _meta.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Copyright © 2019 Alexander L. Hayes
+
+.PHONY : distribution
+
+distribution:
+	pip install --upgrade setuptools wheel twine
+	rm -rf dist/ rnlp.egg-info/ build/
+	python setup.py sdist bdist_wheel
+	python -m twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,33 @@
+########
 ``rnlp``
-========
+########
 
-*Relational NLP Preprocessing: A Python package and tool for converting text into a set of relational facts.*
+|PyPi|_ |License|_ |Travis|_ |Codecov|_ |ReadTheDocs|_
 
-  .. image:: https://img.shields.io/pypi/pyversions/rnlp.svg?style=flat-square
-  .. image:: https://img.shields.io/pypi/v/rnlp.svg?style=flat-square
-  .. image:: https://img.shields.io/pypi/l/rnlp.svg?style=flat-square
-  .. image:: https://img.shields.io/readthedocs/rnlp/stable.svg?flat-square
-	   :target: http://rnlp.readthedocs.io/en/stable/
+.. |PyPi| image:: https://img.shields.io/pypi/pyversions/rnlp.svg
+  :alt: Python Package Index (PyPi) latest version.
+.. _PyPi: https://pypi.org/project/rnlp/
+
+.. |License| image:: https://img.shields.io/github/license/hayesall/rnlp.svg
+  :alt: License.
+.. _License: https://github.com/hayesall/rnlp/blob/master/LICENSE
+
+.. |Travis| image:: https://travis-ci.org/hayesall/rnlp.svg?branch=master
+  :alt: Master branch build status.
+.. _Travis: https://travis-ci.org/hayesall/rnlp
+
+.. |Codecov| image:: https://codecov.io/gh/hayesall/rnlp/branch/master/graphs/badge.svg?branch=master
+  :alt: Master branch code coverage.
+.. _Codecov: https://codecov.io/github/hayesall/rnlp?branch=master
+
+.. |ReadTheDocs| image:: https://readthedocs.org/projects/rnlp/badge/?version=latest
+  :alt: Documentation build status and link to documentation.
+.. _ReadTheDocs: http://rnlp.readthedocs.io/en/latest/
+
+Relational NLP Preprocessing (**rnlp**): A Python package and tool for converting text into a set of relational facts.
+
+- **Documentation**: https://rnlp.readthedocs.io/en/latest/
+- **Questions?**: Contact `Alexander L. Hayes (hayesall) <https://hayesall.com>`_
 
 Installation
 ------------
@@ -17,12 +37,6 @@ Stable builds on PyPi
 .. code-block:: bash
 
 		pip install rnlp
-
-Development builds on GitHub
-
-.. code-block:: bash
-
-		pip install git+git://github.com/starling-lab/rnlp.git
 
 Quick-Start
 -----------
@@ -43,39 +57,38 @@ Quick-Start
 
 The relations created by ``rnlp`` include the following:
 
-  * Sentence's Relative Position in Block:
+* Sentence's Relative Position in Block:
 
-    * ``earlySentenceInBlock``: Sentence occurs within the first third of a block.
-    * ``midWaySentenceInBlock``: Sentence occurs between the first third and the last third of a block's length.
-    * ``lateSentenceInBlock``: Sentence occurs within the last third of a block's length.
+  * ``earlySentenceInBlock``: Sentence occurs within the first third of a block.
+  * ``midWaySentenceInBlock``: Sentence occurs between the first third and the last third of a block's length.
+  * ``lateSentenceInBlock``: Sentence occurs within the last third of a block's length.
 
-  * Word's Relative Position in Sentence:
+* Word's Relative Position in Sentence:
 
-    * ``earlyWordInSentence``: Word occurs within the first third of a sentence.
-    * ``midWayWordInSentence``: Word occurs between a third and two-thirds of a sentence.
-    * ``lateWordInSentence``: Word occurs within the last third of a sentence.
+  * ``earlyWordInSentence``: Word occurs within the first third of a sentence.
+  * ``midWayWordInSentence``: Word occurs between a third and two-thirds of a sentence.
+  * ``lateWordInSentence``: Word occurs within the last third of a sentence.
 
-  * Relative Position Between Items:
+* Relative Position Between Items:
 
-    * ``nextWordInSentence``: Pointer from a word to its neighbor.
-    * ``nextSentenceInBlock``: Pointer from a sentence to its neighbor.
+  * ``nextWordInSentence``: Pointer from a word to its neighbor.
+  * ``nextSentenceInBlock``: Pointer from a sentence to its neighbor.
 
-  * Existential Semantics:
+* Existential Semantics:
 
-    * ``sentenceInBlock``: Sentence occurs in a particular block.
-    * ``wordInSentence``: Word occurs in a particular sentence.
+  * ``sentenceInBlock``: Sentence occurs in a particular block.
+  * ``wordInSentence``: Word occurs in a particular sentence.
 
-  * Low-Level Information about words:
+* Low-Level Information about words:
 
-    * ``wordString``: A string representation of a word.
-    * ``partOfSpeechTag``: The word's part of speech (as determined by the nltk part-of-speech tagger).
+  * ``wordString``: A string representation of a word.
+  * ``partOfSpeechTag``: The word's part of speech (as determined by the nltk part-of-speech tagger).
 
 ---
 
 Files contain a toy corpus (``example files/``) and an image of a BoostSRL tree for predicting if a word in a sentence is the word "you".
 
-.. image:: https://raw.githubusercontent.com/starling-lab/rnlp/master/documentation/img/output.png
+.. image:: https://raw.githubusercontent.com/hayesall/rnlp/master/documentation/img/output.png
 
 The tree says that if the word string contained in word 'b' is "you" then 'b' is the word "you" with a high probability. (This is of course true).
 A more interesting inference is the False branch that says that if word 'b' is an early word in sentence 'a' and word 'anon12035' is also an early word in sentence 'a' and if the word string contained in word 'anon12035' is "Thank", then the word 'b' has decent chance of being the word "you". (The model was able to learn that the word "you" often occurs with the word "Thank" in the same sentence when "Thank" appears early in that sentence).
-

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 |PyPi|_ |License|_ |Travis|_ |Codecov|_ |ReadTheDocs|_
 
-.. |PyPi| image:: https://img.shields.io/pypi/pyversions/rnlp.svg
+.. |PyPi| image:: https://img.shields.io/pypi/v/rnlp.svg
   :alt: Python Package Index (PyPi) latest version.
 .. _PyPi: https://pypi.org/project/rnlp/
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -49,8 +49,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'rnlp'
-copyright = '2017-2018, StARLinG Lab'
-author = 'Alexander L. Hayes (@batflyer), Kaushik Roy (@kkroy36)'
+copyright = '2019 Alexander L. Hayes'
+author = 'Alexander L. Hayes (@hayesall)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -145,7 +145,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'rnlp.tex', 'rnlp Documentation',
-     'Alexander L. Hayes (@batflyer), Kaushik Roy (@kkroy36)', 'manual'),
+     'Alexander L. Hayes (@hayesall)', 'manual'),
 ]
 
 
@@ -169,6 +169,3 @@ texinfo_documents = [
      author, 'rnlp', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/documentation/source/getting_started/02_installation.rst
+++ b/documentation/source/getting_started/02_installation.rst
@@ -8,12 +8,6 @@ Stable builds on PyPi
 
 		pip install rnlp
 
-Development builds on GitHub
-
-.. code-block:: bash
-
-		pip install git+git://github.com/starling-lab/rnlp.git
-
 Some modules in nltk need to be available:
 
 .. code-block:: bash

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -10,8 +10,8 @@
   into a set of relational facts.
 
 
-  :Source Code: `GitHub <https://github.com/starling-lab/rnlp>`_
-  :Bugtracker: `GitHub Issues <https://github.com/starling-lab/rnlp/issues/>`_
+  :Source Code: `GitHub <https://github.com/hayesall/rnlp>`_
+  :Bugtracker: `GitHub Issues <https://github.com/hayesall/rnlp/issues/>`_
 
   .. image:: https://img.shields.io/pypi/pyversions/rnlp.svg?style=flat-square
   .. image:: https://img.shields.io/pypi/v/rnlp.svg?style=flat-square

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+nltk
+tqdm

--- a/rnlp/__init__.py
+++ b/rnlp/__init__.py
@@ -1,4 +1,8 @@
-# Copyright (C) 2017-2018 StARLinG Lab
+
+# -*- coding: utf-8 -*-
+
+# Copyright © 2017-2018 StARLinG Lab
+# Copyright © 2019 Alexander L. Hayes
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -60,18 +64,18 @@ from .textprocessing import getBlocks
 from .textprocessing import getSentences
 from .parse import makeIdentifiers
 
-__author__ = 'Kaushik Roy (@kkroy36)'
-__copyright__ = 'Copyright (c) 2017-2018 StARLinG Lab'
+__author__ = 'Alexander L. Hayes (@hayesall)'
+__copyright__ = 'Copyright © 2017-2018 StARLinG Lab; Copyright © 2019 Alexander L. Hayes'
 __license__ = 'GPL-v3'
 
 __version__ = '0.3.2'
 __status__ = 'Beta'
-__maintainer__ = 'Alexander L. Hayes (@batflyer)'
-__email__ = 'alexander.hayes@utdallas.edu'
+__maintainer__ = 'Alexander L. Hayes (@hayesall)'
+__email__ = 'hayesall@iu.edu'
 
 __credits__ = [
     'Kaushik Roy (@kkroy36)',
-    'Alexander L. Hayes (@batflyer)',
+    'Alexander L. Hayes (@hayesall)',
     'Sriraam Natarajan (@boost-starai)',
     'Gautam Kunapuli (@gkunapuli)',
     'Dileep Viswanathan',

--- a/rnlp/__init__.py
+++ b/rnlp/__init__.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # Copyright © 2017-2018 StARLinG Lab
@@ -60,27 +59,18 @@ Examples
                 predicates = rnlp.parse(declaration)
 """
 
+from ._meta import (
+    __author__,
+    __copyright__,
+    __license__,
+    __status__,
+    __maintainer__,
+    __email__,
+    __credits__,
+)
+from .parse import makeIdentifiers
 from .textprocessing import getBlocks
 from .textprocessing import getSentences
-from .parse import makeIdentifiers
-
-__author__ = 'Alexander L. Hayes (@hayesall)'
-__copyright__ = 'Copyright © 2017-2018 StARLinG Lab; Copyright © 2019 Alexander L. Hayes'
-__license__ = 'GPL-v3'
-
-__version__ = '0.3.2'
-__status__ = 'Beta'
-__maintainer__ = 'Alexander L. Hayes (@hayesall)'
-__email__ = 'hayesall@iu.edu'
-
-__credits__ = [
-    'Kaushik Roy (@kkroy36)',
-    'Alexander L. Hayes (@hayesall)',
-    'Sriraam Natarajan (@boost-starai)',
-    'Gautam Kunapuli (@gkunapuli)',
-    'Dileep Viswanathan',
-    'Rahul Pasunuri'
-]
 
 
 def converter(input_string, block_size=2):
@@ -93,6 +83,6 @@ def converter(input_string, block_size=2):
     :type block_size: int.
     """
 
-    sentences = textprocessing.getSentences(input_string)
-    blocks = textprocessing.getBlocks(sentences, block_size)
-    parse.makeIdentifiers(blocks)
+    sentences = getSentences(input_string)
+    blocks = getBlocks(sentences, block_size)
+    makeIdentifiers(blocks)

--- a/rnlp/__main__.py
+++ b/rnlp/__main__.py
@@ -1,4 +1,8 @@
-# Copyright (C) 2017-2018 StARLinG Lab
+
+# -*- coding: utf-8 -*-
+
+# Copyright © 2017-2018 StARLinG Lab
+# Copyright © 2019 Alexander L. Hayes
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,18 +26,18 @@ import logging
 
 # === Metadata === #
 
-__author__ = 'Kaushik Roy (@kkroy36)'
-__copyright__ = 'Copyright (c) 2017-2018 StARLinG Lab'
+__author__ = 'Alexander L. Hayes (@hayesall)'
+__copyright__ = 'Copyright © 2017-2018 StARLinG Lab; Copyright © 2019 Alexander L. Hayes'
 __license__ = 'GPL-v3'
 
 __version__ = '0.3.1'
 __status__ = 'Beta'
-__maintainer__ = 'Alexander L. Hayes (@batflyer)'
+__maintainer__ = 'Alexander L. Hayes (@hayesall)'
 __email__ = 'alexander.hayes@utdallas.edu'
 
 __credits__ = [
     'Kaushik Roy (@kkroy36)',
-    'Alexander L. Hayes (@batflyer)',
+    'Alexander L. Hayes (@hayesall)',
     'Sriraam Natarajan (@boost-starai)',
     'Gautam Kunapuli (@gkunapuli)',
     'Dileep Viswanathan',
@@ -59,7 +63,7 @@ logger.info('Started Argument Parser.')
 parser = argparse.ArgumentParser(
     description='''Relational-NLP: A library and tool for converting text
                    into a set of relational facts.''',
-    epilog='''Copyright (c) 2017-2018 StARLinG Lab.'''
+    epilog='''Copyright © 2019 Alexander L. Hayes'''
 )
 
 file_or_dir = parser.add_mutually_exclusive_group()

--- a/rnlp/__main__.py
+++ b/rnlp/__main__.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # Copyright © 2017-2018 StARLinG Lab
@@ -18,110 +17,73 @@
 # along with this program (at the base of this repository). If not,
 # see <http://www.gnu.org/licenses/>
 
-from .parse import *
-from .corpus import readCorpus
+"""
+Main script for rnlp.
+
+.. code-block:: bash
+
+    $ python -m rnlp --help
+"""
 
 import argparse
 import logging
 
-# === Metadata === #
+from .parse import makeIdentifiers
+from .textprocessing import getSentences
+from .textprocessing import getBlocks
+from .corpus import readCorpus
 
-__author__ = 'Alexander L. Hayes (@hayesall)'
-__copyright__ = 'Copyright © 2017-2018 StARLinG Lab; Copyright © 2019 Alexander L. Hayes'
-__license__ = 'GPL-v3'
+from ._meta import __license__, __version__, __copyright__
 
-__version__ = '0.3.1'
-__status__ = 'Beta'
-__maintainer__ = 'Alexander L. Hayes (@hayesall)'
-__email__ = 'alexander.hayes@utdallas.edu'
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
 
-__credits__ = [
-    'Kaushik Roy (@kkroy36)',
-    'Alexander L. Hayes (@hayesall)',
-    'Sriraam Natarajan (@boost-starai)',
-    'Gautam Kunapuli (@gkunapuli)',
-    'Dileep Viswanathan',
-    'Rahul Pasunuri'
-]
+LOG_HANDLER = logging.FileHandler("rnlp_log.log")
+LOG_HANDLER.setLevel(logging.INFO)
+FORMATTER = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+LOG_HANDLER.setFormatter(FORMATTER)
 
-# === Logging === #
+LOGGER.addHandler(LOG_HANDLER)
+LOGGER.info("Started logger.")
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
-log_handler = logging.FileHandler('rnlp_log.log')
-log_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-log_handler.setFormatter(formatter)
-
-logger.addHandler(log_handler)
-logger.info('Started logger.')
-
-# === Argument Parser === #
-
-logger.info('Started Argument Parser.')
-parser = argparse.ArgumentParser(
-    description='''Relational-NLP: A library and tool for converting text
-                   into a set of relational facts.''',
-    epilog='''Copyright © 2019 Alexander L. Hayes'''
+LOGGER.info("Started Argument Parser.")
+PARSER = argparse.ArgumentParser(
+    description="rnlp (v{0}): Convert text into relational facts.".format(__version__),
+    epilog="This program is free software under the {0}. {1}".format(
+        __license__, __copyright__
+    ),
 )
 
-file_or_dir = parser.add_mutually_exclusive_group()
+FILE_OR_DIR = PARSER.add_mutually_exclusive_group()
 
-parser.add_argument('-b', '--blockSize', type=int, default=2,
-                    help='Set the block size')
-file_or_dir.add_argument('-d', '--directory', type=str,
-                         help='Read text from all files in a directory.')
-file_or_dir.add_argument('-f', '--file', type=str,
-                         help='Read from text from a file.')
+PARSER.add_argument("-b", "--blockSize", type=int, default=2, help="Set the block size")
+FILE_OR_DIR.add_argument(
+    "-d", "--directory", type=str, help="Read all .txt files in directory"
+)
+FILE_OR_DIR.add_argument("-f", "--file", type=str, help="Read from one .txt file")
 
-args = parser.parse_args()
-logger.info('Argument Parsing Successful.')
+ARGS = PARSER.parse_args()
+LOGGER.info("Argument Parsing Successful.")
 
-# Set block size.
-n = args.blockSize
-logger.info('blockSize specified as ' + str(n))
+N_BLOCKS = ARGS.blockSize
+LOGGER.info("blockSize specified as %s", N_BLOCKS)
 
-# Set the input file(s).
-if args.file:
-    chosenFile = args.file
-elif args.directory:
-    chosenFile = args.directory
+if ARGS.file:
+    CHOSEN_FILE = ARGS.file
+elif ARGS.directory:
+    CHOSEN_FILE = ARGS.directory
 else:
-    message = 'Error. No file or directory was specified.'
-    logger.error(message)
-    print(message)
+    ERROR_MESSAGE = "Error. No file or directory was specified."
+    LOGGER.error(ERROR_MESSAGE)
+    print(ERROR_MESSAGE)
     exit(1)
 
-# Read the corpus.
-try:
-    corpus = readCorpus(chosenFile)
-except Exception:
-    logger.error('Error while reading corpus.', exc_info=True)
-    exit(2)
+CORPUS = readCorpus(CHOSEN_FILE)
+SENTENCES = getSentences(CORPUS)
+BLOCKS = getBlocks(SENTENCES, N_BLOCKS)
+makeIdentifiers(BLOCKS)
 
-# Get sentences from the corpus.
-try:
-    sentences = getSentences(corpus)
-except Exception:
-    logger.error('Error getting sentences from corpus', exc_info=True)
-    exit(2)
-
-# Create blocks from the sentences.
-try:
-    blocks = getBlocks(sentences, n)
-except Exception:
-    logger.error('Error while creating blocks', exc_info=True)
-    exit(2)
-
-# Make identifiers from the blocks.
-try:
-    makeIdentifiers(blocks)
-except Exception:
-    logger.error('Error while making identifiers.', exc_info=True)
-    exit(2)
-
-logger.info('Reached bottom of ' + __name__ + '.')
-logger.info('Shutting down logger.')
+LOGGER.info("Reached bottom of %s.", __name__)
+LOGGER.info("Shutting down logger.")
 logging.shutdown()
 exit(0)

--- a/rnlp/_meta.py
+++ b/rnlp/_meta.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2019 Alexander L. Hayes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (at the base of this repository). If not,
+# see <http://www.gnu.org/licenses/>
+
+"""
+Metadata for the rnlp package.
+"""
+
+__author__ = "Alexander L. Hayes (@hayesall)"
+__copyright__ = (
+    "Copyright © 2017-2018 StARLinG Lab; Copyright © 2019 Alexander L. Hayes"
+)
+__license__ = "GPL-v3"
+
+__version__ = "0.3.2"
+__status__ = "Beta"
+__maintainer__ = "Alexander L. Hayes (@hayesall)"
+__email__ = "hayesall@iu.edu"
+
+__credits__ = [
+    "Kaushik Roy (@kkroy36)",
+    "Alexander L. Hayes (@hayesall)",
+    "Sriraam Natarajan (@boost-starai)",
+    "Gautam Kunapuli (@gkunapuli)",
+    "Dileep Viswanathan",
+    "Rahul Pasunuri",
+]

--- a/rnlp/corpus.py
+++ b/rnlp/corpus.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # Copyright © 2017-2018 StARLinG Lab
@@ -65,19 +64,17 @@ def readCorpus(location):
     """
     print("Reading corpus from file(s)...")
 
-    corpus = ''
+    corpus = ""
 
-    if '.txt' in location:
-        with open(location) as fp:
-            corpus = fp.read()
+    if ".txt" in location:
+        with open(location) as _fp:
+            corpus = _fp.read()
     else:
-
         dirFiles = listdir(location)
-        nFiles = len(dirFiles)
 
-        for f in tqdm(dirFiles):
-            with open(location+"/"+f) as fp:
-                corpus += fp.read()
+        for file in tqdm(dirFiles):
+            with open(location + "/" + file) as _fp:
+                corpus += _fp.read()
 
     return corpus
 

--- a/rnlp/corpus.py
+++ b/rnlp/corpus.py
@@ -1,4 +1,8 @@
-# Copyright (C) 2017-2018 StARLinG Lab
+
+# -*- coding: utf-8 -*-
+
+# Copyright © 2017-2018 StARLinG Lab
+# Copyright © 2019 Alexander L. Hayes
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/rnlp/parse.py
+++ b/rnlp/parse.py
@@ -23,21 +23,16 @@ rnlp.parse
 ----------
 """
 
-from __future__ import print_function
-from __future__ import division
-
-# Standard Python Library
 import string
-
-# Non-standard Python Library
 import nltk
 from tqdm import tqdm
-from .textprocessing import getSentences
-from .textprocessing import getBlocks
+
+__all__ = ["makeIdentifiers"]
 
 
 def _writeBlock(block, blockID):
-    '''writes the block to a file with the id'''
+    """Writes the blocks to a file with blockID.
+    """
     with open("blockIDs.txt", "a") as fp:
         fp.write("blockID: " + str(blockID) + "\n")
         sentences = ""
@@ -159,8 +154,12 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
 
     print("Creating background file...")
 
-    _writeBk(target=target, treeDepth=treeDepth,
-             nodeSize=nodeSize, numOfClauses=numOfClauses)
+    _writeBk(
+        target=target,
+        treeDepth=treeDepth,
+        nodeSize=nodeSize,
+        numOfClauses=numOfClauses,
+    )
 
     print("Creating identifiers from the blocks...")
 
@@ -212,21 +211,6 @@ def makeIdentifiers(blocks, target="sentenceContainsTarget(+SID,+WID).",
             wEnding = (2*nWords)/float(3)
 
             for word in tokens:
-
-                """
-                if word == "He":
-                    pos = open("pos.txt","a")
-                    word = str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)
-                    sentence = str(blockID)+"_"+str(sentenceID)
-                    pos.write("sentenceContainsTarget("+sentence+","+word+").\n")
-                    pos.close()
-                else:
-                    neg = open("neg.txt","a")
-                    word = str(blockID)+"_"+str(sentenceID)+"_"+str(wordID)
-                    sentence = str(blockID)+"_"+str(sentenceID)
-                    neg.write("sentenceContainsTarget("+sentence+","+word+").\n")
-                    neg.close()
-                """
 
                 # mode: wordString(wordID, #str).
                 ps = "wordString(" + str(blockID) + "_" + str(sentenceID) + \

--- a/rnlp/parse.py
+++ b/rnlp/parse.py
@@ -1,7 +1,8 @@
 
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2017-2018 StARLinG Lab
+# Copyright © 2017-2018 StARLinG Lab
+# Copyright © 2019 Alexander L. Hayes
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/rnlp/textprocessing.py
+++ b/rnlp/textprocessing.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # Copyright © 2017-2018 StARLinG Lab
@@ -38,16 +37,12 @@ A word is a collection of letters...
 The depth of reasoning probably depends on the domain you are working on.
 """
 
-from nltk import word_tokenize
+import string
 from nltk import sent_tokenize
 from nltk.corpus import stopwords
-from nltk.stem.porter import *
 
-import string
-
-_punctuation = string.punctuation
-_stemmer = PorterStemmer()
-_stopwords = stopwords.words('english')
+PUNCTUATION = string.punctuation
+STOPWORDS = stopwords.words("english")
 
 
 def _removePunctuation(text_string):
@@ -66,9 +61,9 @@ def _removePunctuation(text_string):
     'Hello World'
     """
     try:
-        return text_string.translate(None, _punctuation)
+        return text_string.translate(None, PUNCTUATION)
     except TypeError:
-        return text_string.translate(str.maketrans('', '', _punctuation))
+        return text_string.translate(str.maketrans("", "", PUNCTUATION))
 
 
 def _removeStopwords(text_list):
@@ -85,21 +80,21 @@ def _removeStopwords(text_list):
     output_list = []
 
     for word in text_list:
-        if word.lower() not in _stopwords:
+        if word.lower() not in STOPWORDS:
             output_list.append(word)
 
     return output_list
 
 
-def getBlocks(sentences, n):
+def getBlocks(sentences, n_blocks):
     """
     Get blocks of n sentences together.
 
     :param sentences: List of strings where  each string is a sentence.
     :type sentences: list
-    :param n: Maximum blocksize for sentences, i.e. a block will be composed of
-              ``n`` sentences.
-    :type n: int.
+    :param n_blocks: Maximum blocksize for sentences, i.e. a block will be
+              composed of ``n_blocks`` sentences.
+    :type n_blocks: int.
 
     :returns: Blocks of n sentences.
     :rtype: list-of-lists
@@ -119,8 +114,8 @@ def getBlocks(sentences, n):
                     # with 3: [['Hello there', 'How are you', 'I am fine']]
     """
     blocks = []
-    for i in range(0, len(sentences), n):
-        blocks.append(sentences[i:(i+n)])
+    for i in range(0, len(sentences), n_blocks):
+        blocks.append(sentences[i : (i + n_blocks)])
     return blocks
 
 

--- a/rnlp/textprocessing.py
+++ b/rnlp/textprocessing.py
@@ -1,4 +1,8 @@
-# Copyright (C) 2017-2018 StARLinG Lab
+
+# -*- coding: utf-8 -*-
+
+# Copyright © 2017-2018 StARLinG Lab
+# Copyright © 2019 Alexander L. Hayes
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,7 +28,7 @@ stopping, removing punctuation, etc.
 Document Hierarchy
 ------------------
 
-A corpora is a collection of documents.
+A corpus is a collection of documents.
 A document is a collection of chapters.
 A chapter is a collection of paragraphs.
 A paragraph is a collection of sentences.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [metadata]
 license_file = LICENSE
-
-[bdist_wheel]
-
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class Install(_install):
         nltk.download('stopwords')
         nltk.download('averaged_perceptron_tagger')
 
-    
+
 setup(
     name='rnlp',
     version='0.3.2',
@@ -39,9 +39,9 @@ setup(
     description='Converts text corpora into a set of relational facts.',
     long_description=long_description,
 
-    url='https://github.com/starling-lab/rnlp',
+    url='https://github.com/hayesall/rnlp',
 
-    author='Alexander L. Hayes (@batflyer)',
+    author='Alexander L. Hayes (@hayesall)',
     author_email='alexander@batflyer.net',
 
     classifiers=[
@@ -66,14 +66,14 @@ setup(
     keywords='nlp',
 
     project_urls={
-        'Source': 'https://github.com/starling-lab/rnlp',
-        'Tracker': 'https://github.com/starling-lab/rnlp/issues'
+        'Source': 'https://github.com/hayesall/rnlp',
+        'Tracker': 'https://github.com/hayesall/rnlp/issues'
     },
 
     packages=find_packages(exclude=['tests']),
 
     cmdclass={'install': Install},
-    
+
     install_requires=[
         'nltk',
         'tqdm',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ Setup file for rnlp
 
 from setuptools import setup
 from setuptools import find_packages
-from setuptools.command.install import install as _install
 
 from codecs import open
 from os import path
@@ -18,24 +17,6 @@ here = path.abspath(path.dirname(__file__))
 # Get the long description from the README.md
 with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
-
-
-# https://stackoverflow.com/questions/26799894/installing-nltk-data-in-setup-py-script
-class Install(_install):
-    """
-    Overwriting the base class to additionally install nltk packages.
-    """
-
-    def run(self):
-        _install.do_egg_install(self)
-
-        # Install the additional required nltk packages
-        import nltk
-
-        nltk.download("punkt")
-        nltk.download("stopwords")
-        nltk.download("averaged_perceptron_tagger")
-
 
 setup(
     name="rnlp",
@@ -63,7 +44,6 @@ setup(
         "Tracker": "https://github.com/hayesall/rnlp/issues",
     },
     packages=find_packages(exclude=["tests"]),
-    cmdclass={"install": Install},
     install_requires=["nltk", "tqdm", "joblib"],
     setup_requires=["nltk"],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,21 @@
 Setup file for rnlp
 """
 
-from setuptools import setup, find_packages
+from setuptools import setup
+from setuptools import find_packages
 from setuptools.command.install import install as _install
 
 from codecs import open
 from os import path
 
+# Get __version__, __license__ and others from _meta.py
+with open(path.join("rnlp", "_meta.py")) as f:
+    exec(f.read())
+
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README.md
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 
@@ -26,59 +31,39 @@ class Install(_install):
 
         # Install the additional required nltk packages
         import nltk
-        nltk.download('punkt')
-        nltk.download('stopwords')
-        nltk.download('averaged_perceptron_tagger')
+
+        nltk.download("punkt")
+        nltk.download("stopwords")
+        nltk.download("averaged_perceptron_tagger")
 
 
 setup(
-    name='rnlp',
-    version='0.3.2',
-    license='GPL-v3',
-
-    description='Converts text corpora into a set of relational facts.',
+    name="rnlp",
+    version=__version__,
+    license=__license__,
+    description="Converts text corpora into a set of relational facts.",
     long_description=long_description,
-
-    url='https://github.com/hayesall/rnlp',
-
-    author='Alexander L. Hayes (@hayesall)',
-    author_email='alexander@batflyer.net',
-
+    url="https://github.com/hayesall/rnlp",
+    author=__author__,
+    author_email=__email__,
     classifiers=[
-        # Development Information
-        'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-
-        # Intended primarily for research use
-        'Intended Audience :: Science/Research',
-
-        # Tested Operating Systems
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: Microsoft :: Windows :: Windows 10',
-
-        # Supported Python Versions.
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Intended Audience :: Science/Research",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Microsoft :: Windows :: Windows 10",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-
-    keywords='nlp',
-
+    keywords="nlp",
     project_urls={
-        'Source': 'https://github.com/hayesall/rnlp',
-        'Tracker': 'https://github.com/hayesall/rnlp/issues'
+        "Source": "https://github.com/hayesall/rnlp",
+        "Tracker": "https://github.com/hayesall/rnlp/issues",
     },
-
-    packages=find_packages(exclude=['tests']),
-
-    cmdclass={'install': Install},
-
-    install_requires=[
-        'nltk',
-        'tqdm',
-        'joblib'
-    ],
-
-    setup_requires=['nltk']
+    packages=find_packages(exclude=["tests"]),
+    cmdclass={"install": Install},
+    install_requires=["nltk", "tqdm", "joblib"],
+    setup_requires=["nltk"],
 )


### PR DESCRIPTION
## Overview

- Add new year and information to new files
- Fix links to reflect repository location
- Fix many pylint warnings by renaming (poorly named) variables
- Drop duplicated tags (e.g. `__version__`, etc.)
- Add tags to `rnlp._meta` so they could be accessed in one place
- Drop the custom `Install` method which installed nltk packages
- Add `Makefile` to automate a few development tasks (notably distribution)