### PR TITLE
🚑 ARGS.output -> ARGS.outputDir

### DIFF
--- a/rnlp/__main__.py
+++ b/rnlp/__main__.py
@@ -83,7 +83,7 @@ else:
 CORPUS = readCorpus(CHOSEN_FILE)
 SENTENCES = getSentences(CORPUS)
 BLOCKS = getBlocks(SENTENCES, N_BLOCKS)
-makeIdentifiers(BLOCKS, outputDir=ARGS.output)
+makeIdentifiers(BLOCKS, outputDir=ARGS.outputDir)
 
 LOGGER.info("Reached bottom of %s.", __name__)
 LOGGER.info("Shutting down logger.")


### PR DESCRIPTION
Fix parameter in `__main__` to correctly refer to `ARGS.outputDir`